### PR TITLE
Mobile client login

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "pg-copy-streams": "^0.3.0",
     "promisepipe": "^1.0.1",
     "qr-image": "^3.1.0",
+    "random-token": "0.0.8",
     "random-uuid-v4": "0.0.5",
     "rc": "~1.0.1",
     "sails": "~0.12.0-rc3",

--- a/tasks/register/dbSetup.js
+++ b/tasks/register/dbSetup.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var extend = require('gextend');
+var buildArguments = require('../_buildArguments');
 
 module.exports = function(grunt) {
 
@@ -56,41 +57,6 @@ function getCommandOptions(config){
     defaults.connection = buildConnectionFromSailsConfig(defaults);
 
     return extend({}, /*config, */defaults, argv);
-}
-
-function buildArguments(defaults) {
-    var args = process.argv.slice(3),
-        K = require('gkeypath');
-
-    function dashToCamel(str) {
-        if(!str) return '';
-
-        return str.replace(/\W+(.)/g, function (x, chr) {
-            return chr.toUpperCase();
-        });
-    }
-
-    var key, value,
-        argv = args.reduce(function(out, option) {
-            option = option.replace('--', '');
-
-            key = option.split('=')[0];
-
-            key = dashToCamel(key);
-
-            if (option.indexOf('=') === -1) value = true;
-            else value = option.split('=')[1];
-
-            typeof value === 'string' && (value = value.split(/,\s?/));
-
-            if(Array.isArray(value) && value.length === 1) value = value[0];
-
-            K.set(out, key, value);
-
-            return out;
-        }, {});
-
-    return argv;
 }
 
 function usage(grunt) {

--- a/tasks/register/iosClientSetup.js
+++ b/tasks/register/iosClientSetup.js
@@ -5,7 +5,7 @@ var buildArguments = require('../_buildArguments');
 module.exports = function (grunt) {
     var Sails = require('sails').Sails;
 
-    grunt.registerTask('menagerie:user', 'Run the database migrations', function (command) {
+    grunt.registerTask('menagerie:user', 'Manage user create|delete|update', function (command) {
         var done = this.async();
 
         var env;
@@ -77,9 +77,90 @@ module.exports = function (grunt) {
                 }
             }
         });
+    });
+
+    //Manage token:
+     grunt.registerTask('menagerie:token', 'Generate API token', function (command) {
+        var done = this.async();
+        var randomToken = require('random-token').create('abcdefghijklmnopqrstuvwxzyABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789');
+
+        var env;
+
+        if (!command) {
+          usage(grunt);
+          return done();
+        }
+
+        if (grunt.option('env')){
+          env = grunt.option('env');
+        }else{
+          env = process.env.NODE_ENV;
+        }
+
+        var config = {
+          port: -1,
+          log: { level: process.env.LOG_LEVEL || 'silent' },
+          environment: env,
+          migrating: true
+        };
+
+        var options = buildArguments();
+
+        // lift Sails to get the effective configuration. We don't actually need to
+        // run it, and we certainly don't want any log messages. We just want the
+        // config.
+        var sails = new Sails();
+        sails.lift(config, function (err) {
+            var url;
+
+            if (err) {
+                grunt.fail.fatal('Could not lift sails', err);
+                return done();
+            }
+
+            exec(command, options, done);
+
+            function onDone(err, res){
+                if(err) grunt.fail.fatal(err);
+                console.log(res);
+                done(err, res);
+            }
+            function exec(command, options, done){
+                console.log('COMMAND', command, 'options', options);
+                switch(command){
+                    case 'create':
+                        var token = randomToken(32) + randomToken(32);
+                        Passport.findOrCreate({
+                            user: options.userid
+                        }, {
+                            user: options.userid,
+                            protocol: 'token',
+                            accessToken: token,
+                            tokens: {
+                                token: token
+                            }
+                        }).exec(onDone);
+                    break;
+                    case 'update':
+                        var id = options.id;
+                            delete options.id;
+                        Passport.update({
+                            accessToken: options.oldToken
+                        }, {accessToken: options.newToken}).exec(onDone);
+                    break;
+                    case 'delete':
+                        Passport.destroy({token: options.token}).exec(onDone);
+                    break;
+                    default:
+                        grunt.log.errorlns('Command not recognized', command);
+                        done();
+                        break;
+                }
+            }
+        });
      });
 };
 
 function usage(grunt){
-
+    console.log('grunt menagerie:user:create --username=<USERNAME> --email=<EMAIL>');
 }


### PR DESCRIPTION
Adds `grunt` task to manage both tokens and users:

Create user:

```
envset development -- grunt menagerie:user:create --username=test_user --email=test_user@menagerie.io
```

Manage passport tokens:

```
envset development -- grunt menagerie:token:create --userid=3
```

This will generate a token similar to the following:

```
3EACCYsnD0zGYDFjqC02iQTUwiQ0NEj72ZESfHRUF0z3Y7NwRNlPFcwjXt5uGfmf
```
